### PR TITLE
커스텀 탭바 구현

### DIFF
--- a/멤버-개발-폴더/홍승현/pillyze/pillyze.xcodeproj/project.pbxproj
+++ b/멤버-개발-폴더/홍승현/pillyze/pillyze.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -371,6 +372,7 @@
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 6.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -400,7 +402,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.whitehyun.pillyze;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -430,7 +432,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.whitehyun.pillyze;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -448,7 +450,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.whitehyun.pillyzeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pillyze.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pillyze";
 			};
@@ -467,7 +469,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.whitehyun.pillyzeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pillyze.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pillyze";
 			};
@@ -484,7 +486,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.whitehyun.pillyzeUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = pillyze;
 			};
@@ -501,7 +503,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.whitehyun.pillyzeUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = pillyze;
 			};

--- a/멤버-개발-폴더/홍승현/pillyze/pillyze.xcodeproj/project.pbxproj
+++ b/멤버-개발-폴더/홍승현/pillyze/pillyze.xcodeproj/project.pbxproj
@@ -393,7 +393,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -423,7 +423,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -445,7 +445,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2ZQR76M3UH;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whitehyun.pillyzeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -464,7 +464,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2ZQR76M3UH;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whitehyun.pillyzeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -482,6 +482,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2ZQR76M3UH;
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whitehyun.pillyzeUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -499,6 +500,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2ZQR76M3UH;
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whitehyun.pillyzeUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/멤버-개발-폴더/홍승현/pillyze/pillyze/Resources/Assets.xcassets/Colors/pillyze-background.colorset/Contents.json
+++ b/멤버-개발-폴더/홍승현/pillyze/pillyze/Resources/Assets.xcassets/Colors/pillyze-background.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFC",
+          "green" : "0xF7",
+          "red" : "0xF8"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFC",
+          "green" : "0xF7",
+          "red" : "0xF8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/ContentView.swift
+++ b/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/ContentView.swift
@@ -8,14 +8,13 @@
 import SwiftUI
 
 struct ContentView: View {
+  @State private var index: Int = 0
   var body: some View {
     VStack {
-      Image(systemName: "globe")
-        .imageScale(.large)
-        .foregroundStyle(.tint)
-      Text("Hello, world!")
+      
+      Spacer()
+      PillyzeTabBar(index: $index)
     }
-    .padding()
   }
 }
 

--- a/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/ContentView.swift
+++ b/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/ContentView.swift
@@ -13,6 +13,14 @@ struct ContentView: View {
     VStack {
       Spacer()
       PillyzeTabBar(index: $index)
+        .frame(height: Metrics.tabBarHeight)
+        .frame(maxWidth: .infinity)
+        .background(
+          UnevenRoundedRectangle(
+            topLeadingRadius: Metrics.cornerRadius,
+            topTrailingRadius: Metrics.cornerRadius
+          ).fill(.background)
+        )
     }
     .background(Color.pillyzeBackground.ignoresSafeArea(edges: .top))
   }
@@ -20,6 +28,7 @@ struct ContentView: View {
 
 
 private enum Metrics {
+  static let cornerRadius: CGFloat = 35
   static let tabBarHeight: CGFloat = 60
 }
 

--- a/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/ContentView.swift
+++ b/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/ContentView.swift
@@ -11,11 +11,16 @@ struct ContentView: View {
   @State private var index: Int = 0
   var body: some View {
     VStack {
-      
       Spacer()
       PillyzeTabBar(index: $index)
     }
+    .background(Color.pillyzeBackground.ignoresSafeArea(edges: .top))
   }
+}
+
+
+private enum Metrics {
+  static let tabBarHeight: CGFloat = 60
 }
 
 #Preview {

--- a/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/PillyzeTabBar.swift
+++ b/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/PillyzeTabBar.swift
@@ -9,17 +9,17 @@ import SwiftUI
 
 struct PillyzeTabBar: View {
   @Binding var index: Int
-  
+
   var body: some View {
     HStack(spacing: 30) {
       Button {
-        
+
       } label: {
         TabBarItem(title: "내 건강", image: Image(systemName: "heart.fill"))
       }
-      
+
       Button {
-        
+
       } label: {
         Image(systemName: "plus")
           .resizable()
@@ -28,24 +28,28 @@ struct PillyzeTabBar: View {
           .foregroundStyle(.white)
           .background(.pillyzePrimary)
           .clipShape(Circle())
-          .offset(y: -8)
+          .offset(y: -Metrics.centerButtonOffset)
       }
-      
+
       Button {
-        
+
       } label: {
         TabBarItem(title: "영양제", image: Image(systemName: "pill.fill"))
       }
     }
-    .frame(width: .infinity, height: 60)
+    .padding(.top, Metrics.centerButtonOffset)
+    .frame(height: Metrics.tabBarHeight)
+    .frame(maxWidth: .infinity)
+    .background(.background)
+    .clipShape(TabBarBackgroundShape())
   }
 }
 
-struct TabBarItem: View {
+private struct TabBarItem: View {
   let title: String
   let image: Image
   var body: some View {
-    VStack(spacing: 8) {
+    VStack(spacing: Metrics.centerButtonOffset) {
       image
       Text(title)
     }
@@ -53,8 +57,57 @@ struct TabBarItem: View {
   }
 }
 
+struct TabBarBackgroundShape: Shape {
+  func path(in rect: CGRect) -> Path {
+    Path { path in
+      path.move(to: .init(x: 0, y: rect.height))
+      path.addLine(to: .init(x: rect.width, y: rect.height))
+      path
+        .addLine(
+          to: .init(
+            x: rect.width,
+            y: Metrics.cornerRadius + Metrics.centerButtonOffset
+          )
+        )
+      path.addArc(
+        tangent1End: .init(x: rect.width, y: Metrics.centerButtonOffset),
+        tangent2End: .init(
+          x: rect.width - Metrics.cornerRadius,
+          y: Metrics.centerButtonOffset
+        ),
+        radius: Metrics.cornerRadius
+      )
+      path
+        .addLine(
+          to: .init(x: Metrics.cornerRadius, y: Metrics.centerButtonOffset)
+        )
+      path.addArc(
+        tangent1End: .init(x: 0, y: Metrics.centerButtonOffset),
+        tangent2End: .init(
+          x: 0,
+          y: Metrics.cornerRadius + Metrics.centerButtonOffset
+        ),
+        radius: Metrics.cornerRadius
+      )
+    }
+  }
+}
 
+private enum Metrics {
+  static let cornerRadius: CGFloat = 35
+  static let centerButtonOffset: CGFloat = 8
+  static let tabBarHeight: CGFloat = 60
+}
 
 #Preview {
   PillyzeTabBar(index: .constant(0))
+}
+
+#Preview("TabBarBackgroundShape") {
+  VStack {
+    Spacer()
+    TabBarBackgroundShape()
+      .frame(width: .infinity, height: Metrics.tabBarHeight)
+      .background(.yellow)
+  }
 }

--- a/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/PillyzeTabBar.swift
+++ b/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/PillyzeTabBar.swift
@@ -11,15 +11,23 @@ struct PillyzeTabBar: View {
   @Binding var index: Int
 
   var body: some View {
-    HStack(spacing: 30) {
-      Button {
+    ZStack {
+      HStack(spacing: 115) {
+        Button {
+          print("건강 탭")
+        } label: {
+          TabBarItem(title: "내 건강", image: Image(systemName: "heart.fill"))
+        }
 
-      } label: {
-        TabBarItem(title: "내 건강", image: Image(systemName: "heart.fill"))
+        Button {
+          print("영양제 탭")
+        } label: {
+          TabBarItem(title: "영양제", image: Image(systemName: "pill.fill"))
+        }
       }
 
       Button {
-
+        print("plus 버튼 탭")
       } label: {
         Image(systemName: "plus")
           .resizable()
@@ -30,18 +38,7 @@ struct PillyzeTabBar: View {
           .clipShape(Circle())
           .offset(y: -Metrics.centerButtonOffset)
       }
-
-      Button {
-
-      } label: {
-        TabBarItem(title: "영양제", image: Image(systemName: "pill.fill"))
-      }
     }
-    .padding(.top, Metrics.centerButtonOffset)
-    .frame(height: Metrics.tabBarHeight)
-    .frame(maxWidth: .infinity)
-    .background(.background)
-    .clipShape(TabBarBackgroundShape())
   }
 }
 
@@ -57,57 +54,10 @@ private struct TabBarItem: View {
   }
 }
 
-struct TabBarBackgroundShape: Shape {
-  func path(in rect: CGRect) -> Path {
-    Path { path in
-      path.move(to: .init(x: 0, y: rect.height))
-      path.addLine(to: .init(x: rect.width, y: rect.height))
-      path
-        .addLine(
-          to: .init(
-            x: rect.width,
-            y: Metrics.cornerRadius + Metrics.centerButtonOffset
-          )
-        )
-      path.addArc(
-        tangent1End: .init(x: rect.width, y: Metrics.centerButtonOffset),
-        tangent2End: .init(
-          x: rect.width - Metrics.cornerRadius,
-          y: Metrics.centerButtonOffset
-        ),
-        radius: Metrics.cornerRadius
-      )
-      path
-        .addLine(
-          to: .init(x: Metrics.cornerRadius, y: Metrics.centerButtonOffset)
-        )
-      path.addArc(
-        tangent1End: .init(x: 0, y: Metrics.centerButtonOffset),
-        tangent2End: .init(
-          x: 0,
-          y: Metrics.cornerRadius + Metrics.centerButtonOffset
-        ),
-        radius: Metrics.cornerRadius
-      )
-    }
-  }
-}
-
 private enum Metrics {
-  static let cornerRadius: CGFloat = 35
   static let centerButtonOffset: CGFloat = 8
-  static let tabBarHeight: CGFloat = 60
 }
 
 #Preview {
   PillyzeTabBar(index: .constant(0))
-}
-
-#Preview("TabBarBackgroundShape") {
-  VStack {
-    Spacer()
-    TabBarBackgroundShape()
-      .frame(width: .infinity, height: Metrics.tabBarHeight)
-      .background(.yellow)
-  }
 }

--- a/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/PillyzeTabBar.swift
+++ b/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/PillyzeTabBar.swift
@@ -11,7 +11,7 @@ struct PillyzeTabBar: View {
   @Binding var index: Int
   
   var body: some View {
-    HStack(spacing: 115) {
+    HStack(spacing: 30) {
       Button {
         
       } label: {
@@ -21,10 +21,23 @@ struct PillyzeTabBar: View {
       Button {
         
       } label: {
+        Image(systemName: "plus")
+          .resizable()
+          .frame(width: 24, height: 24)
+          .frame(maxWidth: 56, maxHeight: 56)
+          .foregroundStyle(.white)
+          .background(.pillyzePrimary)
+          .clipShape(Circle())
+          .offset(y: -8)
+      }
+      
+      Button {
+        
+      } label: {
         TabBarItem(title: "영양제", image: Image(systemName: "pill.fill"))
       }
     }
-    .frame(width: .infinity)
+    .frame(width: .infinity, height: 60)
   }
 }
 
@@ -36,7 +49,7 @@ struct TabBarItem: View {
       image
       Text(title)
     }
-    .frame(width: 60)
+    .frame(width: 82)
   }
 }
 

--- a/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/PillyzeTabBar.swift
+++ b/멤버-개발-폴더/홍승현/pillyze/pillyze/Sources/PillyzeTabBar.swift
@@ -1,0 +1,47 @@
+//
+//  PillyzeTabBar.swift
+//  pillyze
+//
+//  Created by 홍승현 on 7/13/24.
+//
+
+import SwiftUI
+
+struct PillyzeTabBar: View {
+  @Binding var index: Int
+  
+  var body: some View {
+    HStack(spacing: 115) {
+      Button {
+        
+      } label: {
+        TabBarItem(title: "내 건강", image: Image(systemName: "heart.fill"))
+      }
+      
+      Button {
+        
+      } label: {
+        TabBarItem(title: "영양제", image: Image(systemName: "pill.fill"))
+      }
+    }
+    .frame(width: .infinity)
+  }
+}
+
+struct TabBarItem: View {
+  let title: String
+  let image: Image
+  var body: some View {
+    VStack(spacing: 8) {
+      image
+      Text(title)
+    }
+    .frame(width: 60)
+  }
+}
+
+
+
+#Preview {
+  PillyzeTabBar(index: .constant(0))
+}

--- a/멤버-개발-폴더/홍승현/pillyze/pillyzeUITests/pillyzeUITestsLaunchTests.swift
+++ b/멤버-개발-폴더/홍승현/pillyze/pillyzeUITests/pillyzeUITestsLaunchTests.swift
@@ -8,11 +8,11 @@
 import XCTest
 
 final class pillyzeUITestsLaunchTests: XCTestCase {
-  
+
   override class var runsForEachTargetApplicationUIConfiguration: Bool {
     true
   }
-  
+
   override func setUpWithError() throws {
     continueAfterFailure = false
   }


### PR DESCRIPTION
## Screenshots 📸

|Tab bar Screen|
|:-:|
|<img src="https://github.com/user-attachments/assets/bd17c3a7-af4a-4210-a890-66ae6ed2d06e" width="30%"/>|


## Explanation ✍

기존 탭바로 구현하기 어렵다 판단하여 커스텀화를 시도
처음에는 Path를 사용하였음.
`addLine`과 `addArc(tangent1End:tangent2End:radius:transform:)`을 이용하여 그렸음.

|tangent1End와 tangent2End의 간략한 그림|
|:-:|
|![image](https://github.com/user-attachments/assets/b277cf42-96af-431f-84de-c5db38ddd994)|


`clipShape`로 clipping하려고 했지만 약간 삐져나온 가운데 `+`모양의 버튼이 잘리는 현상 발생
<img alt="Simulator Screenshot - iPhone 15 Pro - 2024-07-13 at 07 03 35" src="https://github.com/user-attachments/assets/b732464f-84b3-4638-9af0-df43cd1647ed" width="30%"/>
따라서 Path 방식을 버리고 `iOS16.0`부터 제공되는 `UnevenRoundedRectangle`을 background로 적용하고, 가운데 버튼은 ZStack으로 띄우는 방식으로 해결.
`UnevenRoundedRectangle`는 특정 모서리에 cornerRadius를 설정할 수 있다.